### PR TITLE
fix(xsdany): map xml namespace URI to canonical 'xml' prefix

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -48,12 +48,13 @@ type Document struct {
 	footers []*wml.Ftr
 	ftrRels []common.Relationships
 
-	docRels     common.Relationships
-	themes      []*dml.Theme
-	webSettings *wml.WebSettings
-	fontTable   *wml.Fonts
-	endNotes    *wml.Endnotes
-	footNotes   *wml.Footnotes
+	docRels       common.Relationships
+	themes        []*dml.Theme
+	webSettings   *wml.WebSettings
+	fontTable     *wml.Fonts
+	endNotes      *wml.Endnotes
+	footNotes     *wml.Footnotes
+	imageZipPaths map[string]int // zip path → 1-based index in d.Images; used to deduplicate shared images
 }
 
 // New constructs an empty document that content can be added to.
@@ -75,6 +76,7 @@ func New() *Document {
 	d.Styles.InitializeDefault()
 	d.Comments = NewComments(d)
 	d.CommentsExtended = NewCommentsExtended()
+	d.imageZipPaths = map[string]int{}
 
 	return d
 }
@@ -847,27 +849,38 @@ func (d *Document) onNewRelationship(decMap *zippkg.DecodeMap, target, typ strin
 
 	case unioffice.ImageType, unioffice.ImageTypeStrict:
 		var iref common.ImageRef
-		for i, f := range files {
-			if f == nil {
-				continue
-			}
-			if f.Name == target {
-				path, err := zippkg.ExtractToDiskTmp(f, d.TmpPath)
-				if err != nil {
-					return err
+		// Check if this zip path was already loaded (e.g. the same image is
+		// referenced by multiple headers).  If so, reuse the existing ImageRef
+		// so we don't emit a broken relationship pointing at a non-existent
+		// second copy of the file.
+		if idx, ok := d.imageZipPaths[target]; ok {
+			iref = d.Images[idx-1]
+		} else {
+			for i, f := range files {
+				if f == nil {
+					continue
 				}
-				img, err := common.ImageFromFile(path)
-				if err != nil {
-					return err
+				if f.Name == target {
+					path, err := zippkg.ExtractToDiskTmp(f, d.TmpPath)
+					if err != nil {
+						return err
+					}
+					img, err := common.ImageFromFile(path)
+					if err != nil {
+						return err
+					}
+					iref = common.MakeImageRef(img, &d.DocBase, d.docRels)
+					d.Images = append(d.Images, iref)
+					d.imageZipPaths[target] = len(d.Images)
+					files[i] = nil
 				}
-				iref = common.MakeImageRef(img, &d.DocBase, d.docRels)
-				d.Images = append(d.Images, iref)
-				files[i] = nil
 			}
 		}
 
 		ext := "." + strings.ToLower(iref.Format())
-		rel.TargetAttr = unioffice.RelativeFilename(dt, src.Typ, typ, len(d.Images))
+		// Use the index of the image this rel points to (reused or newly added).
+		imgIdx := d.imageZipPaths[target]
+		rel.TargetAttr = unioffice.RelativeFilename(dt, src.Typ, typ, imgIdx)
 		// ensure we don't change image formats
 		if newExt := filepath.Ext(rel.TargetAttr); newExt != ext {
 			rel.TargetAttr = rel.TargetAttr[0:len(rel.TargetAttr)-len(newExt)] + ext

--- a/document/document.go
+++ b/document/document.go
@@ -877,6 +877,15 @@ func (d *Document) onNewRelationship(decMap *zippkg.DecodeMap, target, typ strin
 			}
 		}
 
+		// Ensure the content-type for the (possibly normalised) extension is
+		// registered.  ImageFromFile uses Go's image library which always
+		// reports "jpeg" (never "jpg"), so without this the Content_Types.xml
+		// would keep the original "jpg" default from the template while the
+		// saved file is named ".jpeg", causing Word to reject it.
+		if iref.Format() != "" {
+			d.ContentTypes.EnsureDefault(strings.ToLower(iref.Format()), "image/"+strings.ToLower(iref.Format()))
+		}
+
 		ext := "." + strings.ToLower(iref.Format())
 		// Use the index of the image this rel points to (reused or newly added).
 		imgIdx := d.imageZipPaths[target]

--- a/schema/soo/dml/Blip.go
+++ b/schema/soo/dml/Blip.go
@@ -30,7 +30,6 @@ func (m *Blip) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "a:blip"
 	return m.CT_Blip.MarshalXML(e, start)
 }

--- a/schema/soo/dml/Tbl.go
+++ b/schema/soo/dml/Tbl.go
@@ -30,7 +30,6 @@ func (m *Tbl) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "a:tbl"
 	return m.CT_Table.MarshalXML(e, start)
 }

--- a/schema/soo/dml/TblStyleLst.go
+++ b/schema/soo/dml/TblStyleLst.go
@@ -30,7 +30,6 @@ func (m *TblStyleLst) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "a:tblStyleLst"
 	return m.CT_TableStyleList.MarshalXML(e, start)
 }

--- a/schema/soo/dml/Theme.go
+++ b/schema/soo/dml/Theme.go
@@ -30,7 +30,6 @@ func (m *Theme) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "a:theme"
 	return m.CT_OfficeStyleSheet.MarshalXML(e, start)
 }

--- a/schema/soo/dml/ThemeManager.go
+++ b/schema/soo/dml/ThemeManager.go
@@ -29,7 +29,6 @@ func (m *ThemeManager) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "a:themeManager"
 	return m.CT_EmptyElement.MarshalXML(e, start)
 }

--- a/schema/soo/dml/ThemeOverride.go
+++ b/schema/soo/dml/ThemeOverride.go
@@ -30,7 +30,6 @@ func (m *ThemeOverride) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "a:themeOverride"
 	return m.CT_BaseStylesOverride.MarshalXML(e, start)
 }

--- a/schema/soo/dml/VideoFile.go
+++ b/schema/soo/dml/VideoFile.go
@@ -30,7 +30,6 @@ func (m *VideoFile) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "a:videoFile"
 	return m.CT_VideoFile.MarshalXML(e, start)
 }

--- a/schema/soo/dml/chart/Chart.go
+++ b/schema/soo/dml/chart/Chart.go
@@ -30,7 +30,6 @@ func (m *Chart) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:c"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/chart"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "c:chart"
 	return m.CT_RelId.MarshalXML(e, start)
 }

--- a/schema/soo/dml/chart/ChartSpace.go
+++ b/schema/soo/dml/chart/ChartSpace.go
@@ -32,7 +32,6 @@ func (m *ChartSpace) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:c"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/chart"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "c:chartSpace"
 	return m.CT_ChartSpace.MarshalXML(e, start)
 }

--- a/schema/soo/dml/chart/UserShapes.go
+++ b/schema/soo/dml/chart/UserShapes.go
@@ -32,7 +32,6 @@ func (m *UserShapes) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:c"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/chart"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "c:userShapes"
 	return m.CT_Drawing.MarshalXML(e, start)
 }

--- a/schema/soo/dml/diagram/ColorsDef.go
+++ b/schema/soo/dml/diagram/ColorsDef.go
@@ -31,7 +31,6 @@ func (m *ColorsDef) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:di"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/diagram"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "colorsDef"
 	return m.CT_ColorTransform.MarshalXML(e, start)
 }

--- a/schema/soo/dml/diagram/ColorsDefHdr.go
+++ b/schema/soo/dml/diagram/ColorsDefHdr.go
@@ -32,7 +32,6 @@ func (m *ColorsDefHdr) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:di"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/diagram"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "colorsDefHdr"
 	return m.CT_ColorTransformHeader.MarshalXML(e, start)
 }

--- a/schema/soo/dml/diagram/ColorsDefHdrLst.go
+++ b/schema/soo/dml/diagram/ColorsDefHdrLst.go
@@ -30,7 +30,6 @@ func (m *ColorsDefHdrLst) MarshalXML(e *xml.Encoder, start xml.StartElement) err
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:di"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/diagram"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "colorsDefHdrLst"
 	return m.CT_ColorTransformHeaderLst.MarshalXML(e, start)
 }

--- a/schema/soo/dml/diagram/DataModel.go
+++ b/schema/soo/dml/diagram/DataModel.go
@@ -31,7 +31,6 @@ func (m *DataModel) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:di"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/diagram"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "dataModel"
 	return m.CT_DataModel.MarshalXML(e, start)
 }

--- a/schema/soo/dml/diagram/LayoutDef.go
+++ b/schema/soo/dml/diagram/LayoutDef.go
@@ -31,7 +31,6 @@ func (m *LayoutDef) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:di"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/diagram"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "layoutDef"
 	return m.CT_DiagramDefinition.MarshalXML(e, start)
 }

--- a/schema/soo/dml/diagram/LayoutDefHdr.go
+++ b/schema/soo/dml/diagram/LayoutDefHdr.go
@@ -32,7 +32,6 @@ func (m *LayoutDefHdr) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:di"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/diagram"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "layoutDefHdr"
 	return m.CT_DiagramDefinitionHeader.MarshalXML(e, start)
 }

--- a/schema/soo/dml/diagram/LayoutDefHdrLst.go
+++ b/schema/soo/dml/diagram/LayoutDefHdrLst.go
@@ -30,7 +30,6 @@ func (m *LayoutDefHdrLst) MarshalXML(e *xml.Encoder, start xml.StartElement) err
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:di"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/diagram"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "layoutDefHdrLst"
 	return m.CT_DiagramDefinitionHeaderLst.MarshalXML(e, start)
 }

--- a/schema/soo/dml/diagram/RelIds.go
+++ b/schema/soo/dml/diagram/RelIds.go
@@ -29,7 +29,6 @@ func (m *RelIds) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:di"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/diagram"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "relIds"
 	return m.CT_RelIds.MarshalXML(e, start)
 }

--- a/schema/soo/dml/diagram/StyleDef.go
+++ b/schema/soo/dml/diagram/StyleDef.go
@@ -31,7 +31,6 @@ func (m *StyleDef) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:di"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/diagram"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "styleDef"
 	return m.CT_StyleDefinition.MarshalXML(e, start)
 }

--- a/schema/soo/dml/diagram/StyleDefHdr.go
+++ b/schema/soo/dml/diagram/StyleDefHdr.go
@@ -32,7 +32,6 @@ func (m *StyleDefHdr) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:di"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/diagram"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "styleDefHdr"
 	return m.CT_StyleDefinitionHeader.MarshalXML(e, start)
 }

--- a/schema/soo/dml/diagram/StyleDefHdrLst.go
+++ b/schema/soo/dml/diagram/StyleDefHdrLst.go
@@ -30,7 +30,6 @@ func (m *StyleDefHdrLst) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:di"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/diagram"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "styleDefHdrLst"
 	return m.CT_StyleDefinitionHeaderLst.MarshalXML(e, start)
 }

--- a/schema/soo/dml/lockedCanvas/LockedCanvas.go
+++ b/schema/soo/dml/lockedCanvas/LockedCanvas.go
@@ -28,7 +28,6 @@ func NewLockedCanvas() *LockedCanvas {
 
 func (m *LockedCanvas) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "lockedCanvas"
 	return m.CT_GvmlGroupShape.MarshalXML(e, start)
 }

--- a/schema/soo/dml/picture/Pic.go
+++ b/schema/soo/dml/picture/Pic.go
@@ -28,7 +28,6 @@ func NewPic() *Pic {
 func (m *Pic) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/picture"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:pic"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/picture"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "pic:pic"
 	return m.CT_Picture.MarshalXML(e, start)
 }

--- a/schema/soo/dml/spreadsheetDrawing/From.go
+++ b/schema/soo/dml/spreadsheetDrawing/From.go
@@ -30,7 +30,6 @@ func (m *From) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "xdr:from"
 	return m.CT_Marker.MarshalXML(e, start)
 }

--- a/schema/soo/dml/spreadsheetDrawing/To.go
+++ b/schema/soo/dml/spreadsheetDrawing/To.go
@@ -30,7 +30,6 @@ func (m *To) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "xdr:to"
 	return m.CT_Marker.MarshalXML(e, start)
 }

--- a/schema/soo/dml/spreadsheetDrawing/WsDr.go
+++ b/schema/soo/dml/spreadsheetDrawing/WsDr.go
@@ -30,7 +30,6 @@ func (m *WsDr) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:a"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "xdr:wsDr"
 	return m.CT_Drawing.MarshalXML(e, start)
 }

--- a/schema/soo/ofc/extended_properties/Properties.go
+++ b/schema/soo/ofc/extended_properties/Properties.go
@@ -28,7 +28,6 @@ func NewProperties() *Properties {
 func (m *Properties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:vt"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "Properties"
 	return m.CT_Properties.MarshalXML(e, start)
 }

--- a/schema/soo/ofc/math/MathPr.go
+++ b/schema/soo/ofc/math/MathPr.go
@@ -30,7 +30,6 @@ func (m *MathPr) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:m"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/math"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "m:mathPr"
 	return m.CT_MathPr.MarshalXML(e, start)
 }

--- a/schema/soo/ofc/math/OMath.go
+++ b/schema/soo/ofc/math/OMath.go
@@ -30,7 +30,6 @@ func (m *OMath) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:m"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/math"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "m:oMath"
 	return m.CT_OMath.MarshalXML(e, start)
 }

--- a/schema/soo/ofc/math/OMathPara.go
+++ b/schema/soo/ofc/math/OMathPara.go
@@ -30,7 +30,6 @@ func (m *OMathPara) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:m"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/math"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "m:oMathPara"
 	return m.CT_OMathPara.MarshalXML(e, start)
 }

--- a/schema/soo/pkg/content_types/Types.go
+++ b/schema/soo/pkg/content_types/Types.go
@@ -27,7 +27,6 @@ func NewTypes() *Types {
 
 func (m *Types) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "http://schemas.openxmlformats.org/package/2006/content-types"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "Types"
 	return m.CT_Types.MarshalXML(e, start)
 }

--- a/schema/soo/pkg/metadata/core_properties/CoreProperties.go
+++ b/schema/soo/pkg/metadata/core_properties/CoreProperties.go
@@ -31,7 +31,6 @@ func (m *CoreProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:cp"}, Value: "http://schemas.openxmlformats.org/package/2006/metadata/core-properties"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:dc"}, Value: "http://purl.org/dc/elements/1.1/"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:dcterms"}, Value: "http://purl.org/dc/terms/"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "cp:coreProperties"
 	return m.CT_CoreProperties.MarshalXML(e, start)
 }

--- a/schema/soo/pkg/relationships/Relationships.go
+++ b/schema/soo/pkg/relationships/Relationships.go
@@ -27,7 +27,6 @@ func NewRelationships() *Relationships {
 
 func (m *Relationships) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "http://schemas.openxmlformats.org/package/2006/relationships"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "Relationships"
 	return m.CT_Relationships.MarshalXML(e, start)
 }

--- a/schema/soo/pml/CmAuthorLst.go
+++ b/schema/soo/pml/CmAuthorLst.go
@@ -31,7 +31,6 @@ func (m *CmAuthorLst) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:cmAuthorLst"
 	return m.CT_CommentAuthorList.MarshalXML(e, start)
 }

--- a/schema/soo/pml/CmLst.go
+++ b/schema/soo/pml/CmLst.go
@@ -31,7 +31,6 @@ func (m *CmLst) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:cmLst"
 	return m.CT_CommentList.MarshalXML(e, start)
 }

--- a/schema/soo/pml/HandoutMaster.go
+++ b/schema/soo/pml/HandoutMaster.go
@@ -31,7 +31,6 @@ func (m *HandoutMaster) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:handoutMaster"
 	return m.CT_HandoutMaster.MarshalXML(e, start)
 }

--- a/schema/soo/pml/Notes.go
+++ b/schema/soo/pml/Notes.go
@@ -33,7 +33,6 @@ func (m *Notes) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:notes"
 	return m.CT_NotesSlide.MarshalXML(e, start)
 }

--- a/schema/soo/pml/NotesMaster.go
+++ b/schema/soo/pml/NotesMaster.go
@@ -32,7 +32,6 @@ func (m *NotesMaster) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:notesMaster"
 	return m.CT_NotesMaster.MarshalXML(e, start)
 }

--- a/schema/soo/pml/OleObj.go
+++ b/schema/soo/pml/OleObj.go
@@ -32,7 +32,6 @@ func (m *OleObj) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:oleObj"
 	return m.CT_OleObject.MarshalXML(e, start)
 }

--- a/schema/soo/pml/Presentation.go
+++ b/schema/soo/pml/Presentation.go
@@ -33,7 +33,6 @@ func (m *Presentation) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:presentation"
 	return m.CT_Presentation.MarshalXML(e, start)
 }

--- a/schema/soo/pml/PresentationPr.go
+++ b/schema/soo/pml/PresentationPr.go
@@ -32,7 +32,6 @@ func (m *PresentationPr) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:presentationPr"
 	return m.CT_PresentationProperties.MarshalXML(e, start)
 }

--- a/schema/soo/pml/Sld.go
+++ b/schema/soo/pml/Sld.go
@@ -33,7 +33,6 @@ func (m *Sld) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:sld"
 	return m.CT_Slide.MarshalXML(e, start)
 }

--- a/schema/soo/pml/SldLayout.go
+++ b/schema/soo/pml/SldLayout.go
@@ -33,7 +33,6 @@ func (m *SldLayout) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:sldLayout"
 	return m.CT_SlideLayout.MarshalXML(e, start)
 }

--- a/schema/soo/pml/SldMaster.go
+++ b/schema/soo/pml/SldMaster.go
@@ -32,7 +32,6 @@ func (m *SldMaster) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:sldMaster"
 	return m.CT_SlideMaster.MarshalXML(e, start)
 }

--- a/schema/soo/pml/SldSyncPr.go
+++ b/schema/soo/pml/SldSyncPr.go
@@ -31,7 +31,6 @@ func (m *SldSyncPr) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:sldSyncPr"
 	return m.CT_SlideSyncProperties.MarshalXML(e, start)
 }

--- a/schema/soo/pml/TagLst.go
+++ b/schema/soo/pml/TagLst.go
@@ -31,7 +31,6 @@ func (m *TagLst) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:tagLst"
 	return m.CT_TagList.MarshalXML(e, start)
 }

--- a/schema/soo/pml/ViewPr.go
+++ b/schema/soo/pml/ViewPr.go
@@ -33,7 +33,6 @@ func (m *ViewPr) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:p"}, Value: "http://schemas.openxmlformats.org/presentationml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:sh"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "p:viewPr"
 	return m.CT_ViewProperties.MarshalXML(e, start)
 }

--- a/schema/soo/schemaLibrary/SchemaLibrary.go
+++ b/schema/soo/schemaLibrary/SchemaLibrary.go
@@ -28,7 +28,6 @@ func NewSchemaLibrary() *SchemaLibrary {
 func (m *SchemaLibrary) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "http://schemas.openxmlformats.org/schemaLibrary/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:ma"}, Value: "http://schemas.openxmlformats.org/schemaLibrary/2006/main"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:schemaLibrary"
 	return m.CT_SchemaLibrary.MarshalXML(e, start)
 }

--- a/schema/soo/sml/CalcChain.go
+++ b/schema/soo/sml/CalcChain.go
@@ -31,7 +31,6 @@ func (m *CalcChain) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:calcChain"
 	return m.CT_CalcChain.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Chartsheet.go
+++ b/schema/soo/sml/Chartsheet.go
@@ -31,7 +31,6 @@ func (m *Chartsheet) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:chartsheet"
 	return m.CT_Chartsheet.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Comments.go
+++ b/schema/soo/sml/Comments.go
@@ -31,7 +31,6 @@ func (m *Comments) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:comments"
 	return m.CT_Comments.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Connections.go
+++ b/schema/soo/sml/Connections.go
@@ -31,7 +31,6 @@ func (m *Connections) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:connections"
 	return m.CT_Connections.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Dialogsheet.go
+++ b/schema/soo/sml/Dialogsheet.go
@@ -31,7 +31,6 @@ func (m *Dialogsheet) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:dialogsheet"
 	return m.CT_Dialogsheet.MarshalXML(e, start)
 }

--- a/schema/soo/sml/ExternalLink.go
+++ b/schema/soo/sml/ExternalLink.go
@@ -31,7 +31,6 @@ func (m *ExternalLink) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:externalLink"
 	return m.CT_ExternalLink.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Headers.go
+++ b/schema/soo/sml/Headers.go
@@ -32,7 +32,6 @@ func (m *Headers) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:headers"
 	return m.CT_RevisionHeaders.MarshalXML(e, start)
 }

--- a/schema/soo/sml/MapInfo.go
+++ b/schema/soo/sml/MapInfo.go
@@ -31,7 +31,6 @@ func (m *MapInfo) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:MapInfo"
 	return m.CT_MapInfo.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Metadata.go
+++ b/schema/soo/sml/Metadata.go
@@ -31,7 +31,6 @@ func (m *Metadata) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:metadata"
 	return m.CT_Metadata.MarshalXML(e, start)
 }

--- a/schema/soo/sml/PivotCacheDefinition.go
+++ b/schema/soo/sml/PivotCacheDefinition.go
@@ -32,7 +32,6 @@ func (m *PivotCacheDefinition) MarshalXML(e *xml.Encoder, start xml.StartElement
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:pivotCacheDefinition"
 	return m.CT_PivotCacheDefinition.MarshalXML(e, start)
 }

--- a/schema/soo/sml/PivotCacheRecords.go
+++ b/schema/soo/sml/PivotCacheRecords.go
@@ -32,7 +32,6 @@ func (m *PivotCacheRecords) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:pivotCacheRecords"
 	return m.CT_PivotCacheRecords.MarshalXML(e, start)
 }

--- a/schema/soo/sml/PivotTableDefinition.go
+++ b/schema/soo/sml/PivotTableDefinition.go
@@ -32,7 +32,6 @@ func (m *PivotTableDefinition) MarshalXML(e *xml.Encoder, start xml.StartElement
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:pivotTableDefinition"
 	return m.CT_pivotTableDefinition.MarshalXML(e, start)
 }

--- a/schema/soo/sml/QueryTable.go
+++ b/schema/soo/sml/QueryTable.go
@@ -32,7 +32,6 @@ func (m *QueryTable) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:queryTable"
 	return m.CT_QueryTable.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Revisions.go
+++ b/schema/soo/sml/Revisions.go
@@ -31,7 +31,6 @@ func (m *Revisions) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:revisions"
 	return m.CT_Revisions.MarshalXML(e, start)
 }

--- a/schema/soo/sml/SingleXmlCells.go
+++ b/schema/soo/sml/SingleXmlCells.go
@@ -31,7 +31,6 @@ func (m *SingleXmlCells) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:singleXmlCells"
 	return m.CT_SingleXmlCells.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Sst.go
+++ b/schema/soo/sml/Sst.go
@@ -32,7 +32,6 @@ func (m *Sst) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:sst"
 	return m.CT_Sst.MarshalXML(e, start)
 }

--- a/schema/soo/sml/StyleSheet.go
+++ b/schema/soo/sml/StyleSheet.go
@@ -31,7 +31,6 @@ func (m *StyleSheet) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:styleSheet"
 	return m.CT_Stylesheet.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Table.go
+++ b/schema/soo/sml/Table.go
@@ -32,7 +32,6 @@ func (m *Table) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:table"
 	return m.CT_Table.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Users.go
+++ b/schema/soo/sml/Users.go
@@ -32,7 +32,6 @@ func (m *Users) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:users"
 	return m.CT_Users.MarshalXML(e, start)
 }

--- a/schema/soo/sml/VolTypes.go
+++ b/schema/soo/sml/VolTypes.go
@@ -31,7 +31,6 @@ func (m *VolTypes) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:volTypes"
 	return m.CT_VolTypes.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Workbook.go
+++ b/schema/soo/sml/Workbook.go
@@ -31,7 +31,6 @@ func (m *Workbook) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:workbook"
 	return m.CT_Workbook.MarshalXML(e, start)
 }

--- a/schema/soo/sml/Worksheet.go
+++ b/schema/soo/sml/Worksheet.go
@@ -31,7 +31,6 @@ func (m *Worksheet) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xdr"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "ma:worksheet"
 	return m.CT_Worksheet.MarshalXML(e, start)
 }

--- a/schema/soo/wml/Comments.go
+++ b/schema/soo/wml/Comments.go
@@ -35,7 +35,6 @@ func (m *Comments) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w10"}, Value: "http://schemas.microsoft.com/office/word/2010/wordml"}) // This is necessary for paragraph ID
 	start.Name.Local = "w:comments"
 	return m.CT_Comments.MarshalXML(e, start)

--- a/schema/soo/wml/Document.go
+++ b/schema/soo/wml/Document.go
@@ -35,7 +35,6 @@ func (m *Document) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w10"}, Value: "http://schemas.microsoft.com/office/word/2010/wordml"}) // This is necessary for paragraph ID
 	start.Name.Local = "w:document"
 	return m.CT_Document.MarshalXML(e, start)

--- a/schema/soo/wml/Endnotes.go
+++ b/schema/soo/wml/Endnotes.go
@@ -35,7 +35,6 @@ func (m *Endnotes) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w10"}, Value: "http://schemas.microsoft.com/office/word/2010/wordml"}) // This is necessary for paragraph ID
 	start.Name.Local = "w:endnotes"
 	return m.CT_Endnotes.MarshalXML(e, start)

--- a/schema/soo/wml/Fonts.go
+++ b/schema/soo/wml/Fonts.go
@@ -35,7 +35,6 @@ func (m *Fonts) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "w:fonts"
 	return m.CT_FontsList.MarshalXML(e, start)
 }

--- a/schema/soo/wml/Footnotes.go
+++ b/schema/soo/wml/Footnotes.go
@@ -35,7 +35,6 @@ func (m *Footnotes) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w10"}, Value: "http://schemas.microsoft.com/office/word/2010/wordml"}) // This is necessary for paragraph ID
 	start.Name.Local = "w:footnotes"
 	return m.CT_Footnotes.MarshalXML(e, start)

--- a/schema/soo/wml/Ftr.go
+++ b/schema/soo/wml/Ftr.go
@@ -36,7 +36,6 @@ func (m *Ftr) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w10"}, Value: "http://schemas.microsoft.com/office/word/2010/wordml"}) // This is necessary for paragraph ID
 	start.Name.Local = "w:ftr"
 	return m.CT_HdrFtr.MarshalXML(e, start)

--- a/schema/soo/wml/GlossaryDocument.go
+++ b/schema/soo/wml/GlossaryDocument.go
@@ -35,7 +35,6 @@ func (m *GlossaryDocument) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "w:glossaryDocument"
 	return m.CT_GlossaryDocument.MarshalXML(e, start)
 }

--- a/schema/soo/wml/Hdr.go
+++ b/schema/soo/wml/Hdr.go
@@ -36,7 +36,6 @@ func (m *Hdr) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w10"}, Value: "http://schemas.microsoft.com/office/word/2010/wordml"}) // This is necessary for paragraph ID
 	start.Name.Local = "w:hdr"
 	return m.CT_HdrFtr.MarshalXML(e, start)

--- a/schema/soo/wml/Numbering.go
+++ b/schema/soo/wml/Numbering.go
@@ -35,7 +35,6 @@ func (m *Numbering) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "w:numbering"
 	return m.CT_Numbering.MarshalXML(e, start)
 }

--- a/schema/soo/wml/Recipients.go
+++ b/schema/soo/wml/Recipients.go
@@ -35,7 +35,6 @@ func (m *Recipients) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "w:recipients"
 	return m.CT_Recipients.MarshalXML(e, start)
 }

--- a/schema/soo/wml/Settings.go
+++ b/schema/soo/wml/Settings.go
@@ -37,7 +37,6 @@ func (m *Settings) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "w:settings"
 	return m.CT_Settings.MarshalXML(e, start)
 }

--- a/schema/soo/wml/Styles.go
+++ b/schema/soo/wml/Styles.go
@@ -35,7 +35,6 @@ func (m *Styles) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "w:styles"
 	return m.CT_Styles.MarshalXML(e, start)
 }

--- a/schema/soo/wml/TxbxContent.go
+++ b/schema/soo/wml/TxbxContent.go
@@ -36,7 +36,6 @@ func (m *TxbxContent) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "w:txbxContent"
 	return m.CT_TxbxContent.MarshalXML(e, start)
 }

--- a/schema/soo/wml/WdAnchor.go
+++ b/schema/soo/wml/WdAnchor.go
@@ -34,7 +34,6 @@ func (m *WdAnchor) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "wp:anchor"
 	return m.WdCT_Anchor.MarshalXML(e, start)
 }

--- a/schema/soo/wml/WdInline.go
+++ b/schema/soo/wml/WdInline.go
@@ -34,7 +34,6 @@ func (m *WdInline) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "wp:inline"
 	return m.WdCT_Inline.MarshalXML(e, start)
 }

--- a/schema/soo/wml/WdWpc.go
+++ b/schema/soo/wml/WdWpc.go
@@ -33,7 +33,6 @@ func (m *WdWpc) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "wp:wpc"
 	return m.WdCT_WordprocessingCanvas.MarshalXML(e, start)
 }

--- a/schema/soo/wml/WebSettings.go
+++ b/schema/soo/wml/WebSettings.go
@@ -35,7 +35,6 @@ func (m *WebSettings) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:wp"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "w:webSettings"
 	return m.CT_WebSettings.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/office/excel/ClientData.go
+++ b/schema/urn/schemas_microsoft_com/office/excel/ClientData.go
@@ -29,7 +29,6 @@ func NewClientData() *ClientData {
 func (m *ClientData) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "urn:schemas-microsoft-com:office:excel"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:x"}, Value: "urn:schemas-microsoft-com:office:excel"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "x:ClientData"
 	return m.CT_ClientData.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/office/powerpoint/Iscomment.go
+++ b/schema/urn/schemas_microsoft_com/office/powerpoint/Iscomment.go
@@ -26,7 +26,6 @@ func NewIscomment() *Iscomment {
 
 func (m *Iscomment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "urn:schemas-microsoft-com:office:powerpoint"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "iscomment"
 	return m.CT_Empty.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/office/powerpoint/Textdata.go
+++ b/schema/urn/schemas_microsoft_com/office/powerpoint/Textdata.go
@@ -26,7 +26,6 @@ func NewTextdata() *Textdata {
 
 func (m *Textdata) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "urn:schemas-microsoft-com:office:powerpoint"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "textdata"
 	return m.CT_Rel.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/office/word/Anchorlock.go
+++ b/schema/urn/schemas_microsoft_com/office/word/Anchorlock.go
@@ -26,7 +26,6 @@ func NewAnchorlock() *Anchorlock {
 
 func (m *Anchorlock) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "urn:schemas-microsoft-com:office:word"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "anchorlock"
 	return m.CT_AnchorLock.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/office/word/Borderbottom.go
+++ b/schema/urn/schemas_microsoft_com/office/word/Borderbottom.go
@@ -27,7 +27,6 @@ func NewBorderbottom() *Borderbottom {
 
 func (m *Borderbottom) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "urn:schemas-microsoft-com:office:word"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "borderbottom"
 	return m.CT_Border.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/office/word/Borderleft.go
+++ b/schema/urn/schemas_microsoft_com/office/word/Borderleft.go
@@ -27,7 +27,6 @@ func NewBorderleft() *Borderleft {
 
 func (m *Borderleft) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "urn:schemas-microsoft-com:office:word"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "borderleft"
 	return m.CT_Border.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/office/word/Borderright.go
+++ b/schema/urn/schemas_microsoft_com/office/word/Borderright.go
@@ -27,7 +27,6 @@ func NewBorderright() *Borderright {
 
 func (m *Borderright) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "urn:schemas-microsoft-com:office:word"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "borderright"
 	return m.CT_Border.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/office/word/Bordertop.go
+++ b/schema/urn/schemas_microsoft_com/office/word/Bordertop.go
@@ -27,7 +27,6 @@ func NewBordertop() *Bordertop {
 
 func (m *Bordertop) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "urn:schemas-microsoft-com:office:word"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "bordertop"
 	return m.CT_Border.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/office/word/Wrap.go
+++ b/schema/urn/schemas_microsoft_com/office/word/Wrap.go
@@ -26,7 +26,6 @@ func NewWrap() *Wrap {
 
 func (m *Wrap) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "urn:schemas-microsoft-com:office:word"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "wrap"
 	return m.CT_Wrap.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/Background.go
+++ b/schema/urn/schemas_microsoft_com/vml/Background.go
@@ -35,7 +35,6 @@ func (m *Background) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:w"}, Value: "http://schemas.openxmlformats.org/wordprocessingml/2006/main"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:x"}, Value: "urn:schemas-microsoft-com:office:excel"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "v:background"
 	return m.CT_Background.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcBottom.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcBottom.go
@@ -31,7 +31,6 @@ func (m *OfcBottom) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:bottom"
 	return m.OfcCT_StrokeChild.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcClippath.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcClippath.go
@@ -30,7 +30,6 @@ func (m *OfcClippath) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:clippath"
 	return m.OfcCT_ClipPath.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcColumn.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcColumn.go
@@ -31,7 +31,6 @@ func (m *OfcColumn) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:column"
 	return m.OfcCT_StrokeChild.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcComplex.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcComplex.go
@@ -30,7 +30,6 @@ func (m *OfcComplex) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:complex"
 	return m.OfcCT_Complex.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcDiagram.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcDiagram.go
@@ -32,7 +32,6 @@ func (m *OfcDiagram) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:diagram"
 	return m.OfcCT_Diagram.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcEquationxml.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcEquationxml.go
@@ -31,7 +31,6 @@ func (m *OfcEquationxml) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:equationxml"
 	return m.OfcCT_EquationXml.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcFill.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcFill.go
@@ -30,7 +30,6 @@ func (m *OfcFill) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:fill"
 	return m.OfcCT_Fill.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcInk.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcInk.go
@@ -30,7 +30,6 @@ func (m *OfcInk) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:ink"
 	return m.OfcCT_Ink.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcLeft.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcLeft.go
@@ -31,7 +31,6 @@ func (m *OfcLeft) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:left"
 	return m.OfcCT_StrokeChild.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcOLEObject.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcOLEObject.go
@@ -32,7 +32,6 @@ func (m *OfcOLEObject) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:OLEObject"
 	return m.OfcCT_OLEObject.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcRight.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcRight.go
@@ -31,7 +31,6 @@ func (m *OfcRight) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:right"
 	return m.OfcCT_StrokeChild.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcShapedefaults.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcShapedefaults.go
@@ -32,7 +32,6 @@ func (m *OfcShapedefaults) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:shapedefaults"
 	return m.OfcCT_ShapeDefaults.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcShapelayout.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcShapelayout.go
@@ -31,7 +31,6 @@ func (m *OfcShapelayout) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:shapelayout"
 	return m.OfcCT_ShapeLayout.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcSignatureline.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcSignatureline.go
@@ -30,7 +30,6 @@ func (m *OfcSignatureline) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:signatureline"
 	return m.OfcCT_SignatureLine.MarshalXML(e, start)
 }

--- a/schema/urn/schemas_microsoft_com/vml/OfcTop.go
+++ b/schema/urn/schemas_microsoft_com/vml/OfcTop.go
@@ -31,7 +31,6 @@ func (m *OfcTop) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:r"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:s"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"})
 	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:v"}, Value: "urn:schemas-microsoft-com:vml"})
-	start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "xmlns:xml"}, Value: "http://www.w3.org/XML/1998/namespace"})
 	start.Name.Local = "o:top"
 	return m.OfcCT_StrokeChild.MarshalXML(e, start)
 }

--- a/xsdany.go
+++ b/xsdany.go
@@ -38,6 +38,7 @@ var wellKnownSchemas = map[string]string{
 	"wpg":     "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",
 	"wpi":     "http://schemas.microsoft.com/office/word/2010/wordprocessingInk",
 	"wps":     "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
+	"xml":     "http://www.w3.org/XML/1998/namespace",
 	"xsi":     "http://www.w3.org/2001/XMLSchema-instance",
 	"x15ac":   "http://schemas.microsoft.com/office/spreadsheetml/2010/11/ac",
 }


### PR DESCRIPTION
## Summary

- Adds `\"xml\": \"http://www.w3.org/XML/1998/namespace\"` to `wellKnownSchemas` in `xsdany.go`
- When `XSDAny` round-trips an attribute with `Space = \"http://www.w3.org/XML/1998/namespace\"` (e.g. `xml:space=\"preserve\"` from a Word header), `getPrefix()` was generating a synthetic prefix `n` because that URI was not in the known-schemas map, producing corrupt output `n:space=\"preserve\"` with an undeclared `xmlns:n` declaration
- The fix ensures `getPrefix()` returns the canonical `xml` prefix for that URI, so the attribute is serialized correctly as `xml:space=\"preserve\"`

## Root cause

`xsdany.go` `applyToNode()` calls `getPrefix(ns)` for every attribute with a non-empty `Space`. For the standard XML namespace URI (`http://www.w3.org/XML/1998/namespace`), `getPrefix()` fell through to the synthetic-prefix generator which takes the first letter of the last path segment — `\"namespace\"` → `\"n\"`.

## Testing

Covered by the regression test `TestDocxExportATATemplateNoNsPrefix` added in the kvasir repo, which exports a document using ATATemplate.docx (a real-world template with `xml:space=\"preserve\"` in its headers) and asserts that no XML file in the output contains `n:space=`.